### PR TITLE
Remove the ability for a ward to burn anyones dai

### DIFF
--- a/src/Dai.sol
+++ b/src/Dai.sol
@@ -172,7 +172,7 @@ contract Dai {
         uint256 balance = balanceOf[from];
         require(balance >= value, "Dai/insufficient-balance");
 
-        if (from != msg.sender && wards[msg.sender] != 1) {
+        if (from != msg.sender) {
             uint256 allowed = allowance[from][msg.sender];
             if (allowed != type(uint256).max) {
                 require(allowed >= value, "Dai/insufficient-allowance");

--- a/src/test/Dai.t.sol
+++ b/src/test/Dai.t.sol
@@ -54,6 +54,7 @@ contract DaiTest is DSSTest {
 
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(0xBEEF), address(0), 0.9e18);
+        vm.prank(address(0xBEEF));
         token.burn(address(0xBEEF), 0.9e18);
 
         assertEq(token.totalSupply(), 1e18 - 0.9e18);
@@ -323,6 +324,7 @@ contract DaiTest is DSSTest {
 
         vm.expectEmit(true, true, true, true);
         emit Transfer(from, address(0), burnAmount);
+        vm.prank(from);
         token.burn(from, burnAmount);
 
         assertEq(token.totalSupply(), mintAmount - burnAmount);


### PR DESCRIPTION
This is important for censorship prevention from governance. It should not have been added in the first place.